### PR TITLE
Bugfixes for asset paths and exit error log

### DIFF
--- a/base/main.cpp
+++ b/base/main.cpp
@@ -273,8 +273,8 @@ void android_main(struct android_app* app) {
       program->PollActions();
       program->RenderFrame();
     }
-    app->activity->vm->DetachCurrentThread();
     program->DestroySecureMr();
+    app->activity->vm->DetachCurrentThread();
   } catch (const std::exception& ex) {
     Log::Write(Log::Level::Error, ex.what());
   } catch (...) {

--- a/samples/pose/cpp/pose_detection.cpp
+++ b/samples/pose/cpp/pose_detection.cpp
@@ -48,6 +48,9 @@ PoseDetector::PoseDetector(const XrInstance& instance, const XrSession& session)
 
 PoseDetector::~PoseDetector() {
   keepRunning = false;
+  if (pipelineInitializer && pipelineInitializer->joinable()) {
+    pipelineInitializer->join();
+  }
   for (auto& runner : pipelineRunners) {
     if (runner.joinable()) runner.join();
   }

--- a/samples/ufo/build.gradle.kts
+++ b/samples/ufo/build.gradle.kts
@@ -47,7 +47,7 @@ android {
     sourceSets {
         getByName("main") {
             manifest.srcFile("AndroidManifest.xml")
-            assets.srcDirs("../../assets/common", "../../assets/ufo")
+            assets.srcDirs("../../assets/common", "../../assets/UFO")
         }
     }
     packaging {

--- a/samples/ufo/cpp/face_tracking.cpp
+++ b/samples/ufo/cpp/face_tracking.cpp
@@ -44,6 +44,9 @@ FaceTracker::FaceTracker(const XrInstance& instance, const XrSession& session)
 
 FaceTracker::~FaceTracker() {
   keepRunning = false;
+  if (pipelineInitializer && pipelineInitializer->joinable()) {
+    pipelineInitializer->join();
+  }
   for (auto& runner : pipelineRunners) {
     if (runner.joinable()) runner.join();
   }

--- a/samples/ufo_origin/build.gradle.kts
+++ b/samples/ufo_origin/build.gradle.kts
@@ -48,7 +48,7 @@ android {
     sourceSets {
         getByName("main") {
             manifest.srcFile("AndroidManifest.xml")
-            assets.srcDirs("../../assets/common", "../../assets/ufo")
+            assets.srcDirs("../../assets/common", "../../assets/UFO")
         }
     }
     packaging {

--- a/samples/ufo_origin/cpp/face_tracking_raw.cpp
+++ b/samples/ufo_origin/cpp/face_tracking_raw.cpp
@@ -10,6 +10,9 @@ FaceTrackingRaw::FaceTrackingRaw(const XrInstance &instance, const XrSession &se
 
 FaceTrackingRaw::~FaceTrackingRaw() {
   keepRunning = false;
+  if (pipelineInitializer && pipelineInitializer->joinable()) {
+    pipelineInitializer->join();
+  }
   for (auto &runner : pipelineRunners) {
     if (runner.joinable()) runner.join();
   }

--- a/samples/yolo_det/cpp/yolo_object_detection.cpp
+++ b/samples/yolo_det/cpp/yolo_object_detection.cpp
@@ -47,6 +47,9 @@ YoloDetector::YoloDetector(const XrInstance& instance, const XrSession& session)
 
 YoloDetector::~YoloDetector() {
   keepRunning = false;
+  if (pipelineInitializer && pipelineInitializer->joinable()) {
+    pipelineInitializer->join();
+  }
   for (auto& runner : pipelineRunners) {
     if (runner.joinable()) runner.join();
   }


### PR DESCRIPTION
## Summary

Tiny bugfixes, for compatibility across build platforms and multi-thread stability

### Details

* Change the asset path name to avoid missing assets when built on a case-sensitive platform
* Fix the std::exception error log when exiting the sample apps


## Verification

- [x] Use gradle build script to build all three samples. Running them on PICO 4 ULTRA gives results as expected. 